### PR TITLE
Basic optimization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,4 +10,23 @@ dependencies = [
 [[package]]
 name = "brainrust-engine"
 version = "0.1.0"
+dependencies = [
+ "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
+[[package]]
+name = "either"
+version = "1.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "itertools"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[metadata]
+"checksum either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
+"checksum itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"

--- a/brainrust-cli/src/main.rs
+++ b/brainrust-cli/src/main.rs
@@ -5,6 +5,7 @@ use std::time::Instant;
 
 use brainrust_engine::interpreter::Interpreter;
 use brainrust_engine::lexer;
+use brainrust_engine::optimizer;
 use brainrust_engine::parser;
 
 const MEMORY_SIZE: usize = 32768;
@@ -18,9 +19,11 @@ fn main() {
 
     let contents = fs::read_to_string(file).expect("Something went wrong reading the file");
 
-    let parsed = parser::parse(lexer::lex(&contents)).expect("Parsing failure");
+    let tokens = lexer::lex(&contents);
+    let parsed = parser::parse(tokens).expect("Parsing failure");
+    let optimized = optimizer::optimize(parsed);
 
-    println!("File parsed");
+    println!("File parsed and optimized");
 
     let mut interpreter = Interpreter::new(MEMORY_SIZE);
 
@@ -28,7 +31,7 @@ fn main() {
     println!("==================");
 
     let now = Instant::now();
-    let res = interpreter.run(parsed, &mut io::stdin(), &mut io::stdout());
+    let res = interpreter.run(optimized, &mut io::stdin(), &mut io::stdout());
     let elapsed = now.elapsed();
 
     println!("==================");

--- a/brainrust-engine/Cargo.toml
+++ b/brainrust-engine/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+itertools = "0.8.2"

--- a/brainrust-engine/src/interpreter.rs
+++ b/brainrust-engine/src/interpreter.rs
@@ -1,6 +1,7 @@
 use std::io;
 use std::io::Error as IoError;
 
+#[derive(Debug, Copy, Clone)]
 pub enum Instruction {
     MoveRight(usize),
     MoveLeft(usize),

--- a/brainrust-engine/src/lib.rs
+++ b/brainrust-engine/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod interpreter;
 pub mod lexer;
+pub mod optimizer;
 pub mod parser;

--- a/brainrust-engine/src/optimizer.rs
+++ b/brainrust-engine/src/optimizer.rs
@@ -1,0 +1,22 @@
+use crate::interpreter::Instruction;
+use crate::interpreter::Instruction::*;
+use crate::parser;
+
+use itertools::Itertools;
+
+pub fn optimize(instructions: Vec<Instruction>) -> Vec<Instruction> {
+    let mut optimized: Vec<Instruction> = combine_instructions(instructions.into_iter()).collect();
+    parser::link_loops(&mut optimized).unwrap()
+}
+
+fn combine_instructions<It: Iterator<Item = Instruction>>(
+    instructions: It,
+) -> impl Iterator<Item = Instruction> {
+    instructions.coalesce(|previous, current| match (previous, current) {
+        (MoveRight(a), MoveRight(b)) => Ok(MoveRight(a + b)),
+        (MoveLeft(a), MoveLeft(b)) => Ok(MoveLeft(a + b)),
+        (Add(a), Add(b)) => Ok(Add(a + b)),
+        (Sub(a), Sub(b)) => Ok(Sub(a + b)),
+        _ => Err((previous, current)),
+    })
+}

--- a/brainrust-engine/src/parser.rs
+++ b/brainrust-engine/src/parser.rs
@@ -16,12 +16,10 @@ pub fn parse(commands: Vec<Command>) -> Result<Vec<Instruction>, Error> {
         })
         .collect();
 
-    link_loops(&mut instructions)?;
-
-    Ok(instructions)
+    link_loops(&mut instructions)
 }
 
-fn link_loops(program: &mut [Instruction]) -> Result<(), Error> {
+pub fn link_loops(program: &mut Vec<Instruction>) -> Result<Vec<Instruction>, Error> {
     let mut jump_stack = Vec::new();
 
     for i in 0..program.len() {
@@ -46,7 +44,7 @@ fn link_loops(program: &mut [Instruction]) -> Result<(), Error> {
             "Opening bracket missing closing bracket",
         )));
     }
-    Ok(())
+    Ok(program.to_vec())
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
This pull request adds a simple optimizer that merges pointer movements and cell value updates.

For example, if the optimizer finds two instructions in a row that adds 1 to the current cell, it takes those two instructions and replaces them with a single instruction that adds 2 to the current cell, like this: `Add(1), Add(1)` => `Add(2)` 

Since this changes the number of instructions the optimizer needs to re-link the loops, which incurs an extra traversal of the all the instructions. A future version might be able to avoid linking the loops a second time.

Signed-off-by: Emil Englesson <englesson.emil@gmail.com>