### PR TITLE
Terse lexer

### DIFF
--- a/brainrust-engine/src/lexer.rs
+++ b/brainrust-engine/src/lexer.rs
@@ -10,14 +10,7 @@ pub enum Command {
 }
 
 pub fn lex(input: &String) -> Vec<Command> {
-    input
-        .chars()
-        .fold(Vec::with_capacity(input.len()), |mut acc, chr| {
-            if let Some(instruction) = lex_char(chr) {
-                acc.push(instruction);
-            }
-            acc
-        })
+    input.chars().filter_map(lex_char).collect()
 }
 
 fn lex_char(chr: char) -> Option<Command> {


### PR DESCRIPTION
Small refactoring to make the lexer terser. Instead of manually filtering out Options of type `None` the built-in function `filter_map` accomplishes the same.

Signed-off-by: Emil Englesson <englesson.emil@gmail.com>