### PR TITLE
Added two more optimizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Brainrust is a simple Brainfuck interpreter written in Rust. [Brainfuck](https://en.wikipedia.org/wiki/Brainfuck) is a very simple but still Turing complete language with just eight instructions.
 
-Brainrust consists of two parts, the CLI `brainrust-cli` and the engine `brainrust-engine`. The engine exposes methods to lex, parse, optimize and interpret Brainfuck code. The CLI is currently a thin and ***fragile*** wrapper around the engine.
+Brainrust consists of two parts, the CLI `brainrust-cli` and the engine `brainrust-engine`. The engine exposes methods to lex, parse, optimize and interpret Brainfuck code. The CLI is using the engine to interpret Brainfuck programs and is currently quite minimalistic.
 
 This repository is a [Cargo workspace](https://doc.rust-lang.org/book/ch14-03-cargo-workspaces.html) which allows the library to evolve more independently from the CLI and vice versa.
 
@@ -36,7 +36,7 @@ cargo run --release file.b
 
 ## Optimizations
 
-Only two optimization techniques are implemented as of now.
+Below follows a list of optimizations that are currently implemented along with a short description.
 
 **1. Statically linked loops**
 
@@ -59,6 +59,24 @@ Some instructions can be stacked. These stackable instructions (`>`, `<`, `+`, `
 
 ```
 +++++ => [Add(1), Add(1), Add(1), Add(1), Add(1)] => [Add(5)]
+```
+
+**3. Clear loops**
+
+The so called clear loop is a common idiom in Brainfuck. The purpose of the clear loop is to set the current cell to zero which is accomplished with the following loop.
+
+```
+[ - ] => [JumpIfZero(2), Sub(1) JumpIfNotZero(0)] => [Clear]
+```
+
+This can be optimized by replacing the loop with a single custom instruction `Clear`.
+
+**4. Mutation followed by input**
+
+If a cell is mutated and then accept input, the mutation can be omitted. It is unnecessary to carry out instructions that will be replaced by the value of the input.
+
+```
+++++, => [Add(1), Add(1), Add(1), Add(1), Read] => [Read]
 ```
 
 ## Resources

--- a/brainrust-engine/src/interpreter.rs
+++ b/brainrust-engine/src/interpreter.rs
@@ -11,6 +11,7 @@ pub enum Instruction {
     JumpIfNotZero(usize),
     Print,
     Read,
+    Clear,
 }
 
 #[derive(Debug)]
@@ -94,6 +95,9 @@ impl Interpreter {
                     let mut buffer = [0; 1];
                     input.read(&mut buffer)?;
                     self.write_current_cell(buffer[0]);
+                }
+                Instruction::Clear => {
+                    self.write_current_cell(0);
                 }
             }
             next_instruction += 1;

--- a/brainrust-engine/src/optimizer.rs
+++ b/brainrust-engine/src/optimizer.rs
@@ -1,11 +1,17 @@
+use std::ops::Range;
+
+use itertools::Itertools;
+
 use crate::interpreter::Instruction;
 use crate::interpreter::Instruction::*;
 use crate::parser;
 
-use itertools::Itertools;
-
 pub fn optimize(instructions: Vec<Instruction>) -> Vec<Instruction> {
-    let mut optimized: Vec<Instruction> = combine_instructions(instructions.into_iter()).collect();
+    let iter = instructions.into_iter();
+    let iter = combine_instructions(iter);
+    let iter = optimize_clear_loop(iter);
+    let iter = remove_mutation_before_input(iter);
+    let mut optimized = iter.collect();
     parser::link_loops(&mut optimized).unwrap()
 }
 
@@ -17,6 +23,52 @@ fn combine_instructions<It: Iterator<Item = Instruction>>(
         (MoveLeft(a), MoveLeft(b)) => Ok(MoveLeft(a + b)),
         (Add(a), Add(b)) => Ok(Add(a + b)),
         (Sub(a), Sub(b)) => Ok(Sub(a + b)),
+        _ => Err((previous, current)),
+    })
+}
+
+fn optimize_clear_loop<It: Iterator<Item = Instruction>>(
+    instructions: It,
+) -> impl Iterator<Item = Instruction> {
+    fn find_clear_loop(instructions: &Vec<Instruction>) -> Option<Range<usize>> {
+        let mut run_started = false;
+        let mut start = 0;
+        for (i, item) in instructions.iter().enumerate() {
+            match item {
+                JumpIfZero(_a) => {
+                    run_started = true;
+                    start = i;
+                }
+                Sub(_a) => { /* noop */ }
+                JumpIfNotZero(_a) => {
+                    if run_started {
+                        return Some(start..(i + 1));
+                    }
+                }
+                _ => {
+                    run_started = false;
+                }
+            };
+        }
+        None
+    }
+
+    let mut instructions = instructions.collect::<Vec<Instruction>>();
+
+    while let Some(range) = find_clear_loop(&instructions) {
+        instructions.splice(range, vec![Clear].into_iter());
+    }
+
+    instructions.into_iter()
+}
+
+fn remove_mutation_before_input<It: Iterator<Item = Instruction>>(
+    instructions: It,
+) -> impl Iterator<Item = Instruction> {
+    instructions.coalesce(|previous, current| match (previous, current) {
+        (Add(_), Read) => Ok(Read),
+        (Sub(_), Read) => Ok(Read),
+        (Clear, Read) => Ok(Read),
         _ => Err((previous, current)),
     })
 }


### PR DESCRIPTION
This change adds two more simple optimizations.

The first optimization replaces so called clear loops, a common idiom in Brainfuck, with a single custom instruction that sets the current cell to 0.

The second optimization removes unnecessary mutation before input.

Closes #6 

Signed-off-by: Emil Englesson <englesson.emil@gmail.com>