### PR TITLE
Optimizer quick fix

### DIFF
--- a/brainrust-engine/src/optimizer.rs
+++ b/brainrust-engine/src/optimizer.rs
@@ -49,6 +49,8 @@ fn optimize_clear_loop<It: Iterator<Item = Instruction>>(
                         if start + 2 == i {
                             return Some(start..=i);
                         }
+                        // Reset run
+                        run_started = false;
                     }
                 }
                 _ => {


### PR DESCRIPTION
Fixed a bug in the optimizer regarding clear loops. It did not correctly reset loops in cases where there were no clear loop.

Signed-off-by: Emil Englesson <englesson.emil@gmail.com>